### PR TITLE
Hotfix: fix markdown editor updating text only when a full word has been typed.

### DIFF
--- a/nebula/helpers/error_handler.py
+++ b/nebula/helpers/error_handler.py
@@ -13,7 +13,9 @@ def csrf_error_handler(e):
         return jsonify({"message": "CSRF error"}), 419
     """Redirects to the login page if the user is not logged in."""
     flash("Session expired. Please try again.", "warning")
-    return redirect(request.referrer if request.referrer else url_for("web.main.index"))
+    return redirect(
+        request.referrer if request.referrer else url_for("nebula.web.main.index")
+    )
 
 
 def generic_error_handler(e):

--- a/nebula/src/js/components/MarkdownEditor.vue
+++ b/nebula/src/js/components/MarkdownEditor.vue
@@ -249,8 +249,14 @@ const markdownEditorId = ref(
                     @keydown="keyDownHandler"
                     ref="markdownEditElement"
                     :id="markdownEditorId"
-                    @input="emit('update:modelValue', contentEditable)"
-                    v-model="contentEditable"
+                    @input="
+                        (e) => {
+                            // @ts-ignore
+                            contentEditable = e.target.value;
+                            emit('update:modelValue', contentEditable);
+                        }
+                    "
+                    :value="contentEditable"
                 />
                 <div
                     class="syntax-highlighted"


### PR DESCRIPTION
Now the text updates the moment something is entered. It was quite unusable to type something and not see anything until you pressed space.